### PR TITLE
Activating CI only for PRs and main

### DIFF
--- a/.github/workflows/full-deployment.yml
+++ b/.github/workflows/full-deployment.yml
@@ -1,7 +1,11 @@
 name: Opentofu and Quarkus Full Deployment
 on:
   push:
+    branches:
+      - main
   pull_request:
+    branches:
+      - main
 jobs:
   opentofu:
     runs-on: ubuntu-latest
@@ -37,11 +41,11 @@ jobs:
         run: tofu validate
         working-directory: aws-infra
       - name: Tofu Plan
-        run: tofu plan
+        run: tofu plan -out=aws.tfplan
         working-directory: aws-infra
       - name: Tofu Apply
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        run: tofu apply -auto-approve
+        run: tofu apply -auto-approve aws.tfplan
         working-directory: aws-infra
   quarkus:
     needs: opentofu


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for full deployment. The main changes ensure that deployments only run on the `main` branch for both push and pull request events, and that the OpenTofu plan and apply steps use a saved plan file for safer infrastructure changes.

**Workflow trigger updates:**

* The workflow is now restricted to run only on the `main` branch for both `push` and `pull_request` events, preventing deployments from other branches.

**OpenTofu deployment improvements:**

* The `tofu plan` step now saves the plan to a file (`aws.tfplan`) instead of running interactively, allowing for more controlled and auditable deployments.
* The `tofu apply` step now applies the saved plan file (`aws.tfplan`), ensuring that only the planned infrastructure changes are applied.