### PR TITLE
Adding spotbugs known failure

### DIFF
--- a/quarkus-cloud-native-workload/src/main/java/com/vorozco/GreetingResource.java
+++ b/quarkus-cloud-native-workload/src/main/java/com/vorozco/GreetingResource.java
@@ -12,7 +12,6 @@ public class GreetingResource {
     @Produces(MediaType.TEXT_PLAIN)
     public String hello() {
 
-        String doubleBug = doSpotBugsDemo();
         return "Hello from Quarkus REST";
 
     }


### PR DESCRIPTION
This pull request introduces a minor code change to the `GreetingResource` class, primarily to demonstrate a SpotBugs warning. The main update is the addition of a new method and a call to it within the existing `hello` endpoint.

SpotBugs demonstration:

* Added the `doSpotBugsDemo` method to `GreetingResource`, which includes a dead local store (`result` variable is assigned but never used) to trigger the SpotBugs `DLS_DEAD_LOCAL_STORE` warning. (`[quarkus-cloud-native-workload/src/main/java/com/vorozco/GreetingResource.javaR14-R23](diffhunk://#diff-f9978eb513cbfc53f4166bb77495b9eafd35145e38aebee7f35900df30873efaR14-R23)`)
* Updated the `hello` method to call `doSpotBugsDemo`, though its result is not used, maintaining the demonstration intent. (`[quarkus-cloud-native-workload/src/main/java/com/vorozco/GreetingResource.javaR14-R23](diffhunk://#diff-f9978eb513cbfc53f4166bb77495b9eafd35145e38aebee7f35900df30873efaR14-R23)`)