### PR TITLE
Adding live change

### DIFF
--- a/quarkus-cloud-native-workload/src/main/java/com/vorozco/GreetingResource.java
+++ b/quarkus-cloud-native-workload/src/main/java/com/vorozco/GreetingResource.java
@@ -11,12 +11,12 @@ public class GreetingResource {
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     public String hello() {
+        String saludo = doSpotBugsDemo();
         return "Hello from Quarkus REST";
-
     }
 
     private String doSpotBugsDemo(){
-        // SpotBugs: DLS_DEAD_LOCAL_STORE - The value assigned to 'result' is never read
+        String saludo2 = "Saludo 2";
         return "SpotBugs demo";
     }
 }

--- a/quarkus-cloud-native-workload/src/main/java/com/vorozco/GreetingResource.java
+++ b/quarkus-cloud-native-workload/src/main/java/com/vorozco/GreetingResource.java
@@ -11,12 +11,10 @@ public class GreetingResource {
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     public String hello() {
-        String saludo = doSpotBugsDemo();
         return "Hello from Quarkus REST";
     }
 
     private String doSpotBugsDemo(){
-        String saludo2 = "Saludo 2";
         return "SpotBugs demo";
     }
 }


### PR DESCRIPTION
This pull request makes a minor update to the `GreetingResource` class. The main change is the addition of a call to the `doSpotBugsDemo` method inside the `hello` endpoint, and a small modification to the local variable name within `doSpotBugsDemo`.

* The `hello` method now calls `doSpotBugsDemo`, assigning its return value to the local variable `saludo`, though this value is not used. (`[quarkus-cloud-native-workload/src/main/java/com/vorozco/GreetingResource.javaR14-R19](diffhunk://#diff-f9978eb513cbfc53f4166bb77495b9eafd35145e38aebee7f35900df30873efaR14-R19)`)
* The local variable in `doSpotBugsDemo` was renamed from `result` to `saludo2`, but remains unused. (`[quarkus-cloud-native-workload/src/main/java/com/vorozco/GreetingResource.javaR14-R19](diffhunk://#diff-f9978eb513cbfc53f4166bb77495b9eafd35145e38aebee7f35900df30873efaR14-R19)`)